### PR TITLE
[ @efebia/fastify-zod-reply ] - Add support for global schemas

### DIFF
--- a/packages/fastify-zod-reply/package.json
+++ b/packages/fastify-zod-reply/package.json
@@ -15,7 +15,8 @@
         "build:esm": "tsc -p ./tsconfig.build.json --module nodenext --moduleResolution nodenext --outDir lib/esm",
         "build:cjs": "tsc -p ./tsconfig.build.json --module commonjs --moduleResolution node --outDir lib/cjs",
         "build": "yarn build:esm && yarn build:cjs",
-        "test": "node --import tsx --test ./**/*.test.ts"
+        "test": "node --import tsx --test ./**/*.test.ts",
+        "test:single": "node --import tsx --test"
     },
     "main": "./lib/esm/index.js",
     "types": "./lib/esm/index.d.ts",

--- a/packages/fastify-zod-reply/package.json
+++ b/packages/fastify-zod-reply/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@efebia/fastify-zod-reply",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "license": "MIT",
     "dependencies": {
         "fastify": "^5.3.0",

--- a/packages/fastify-zod-reply/src/index.ts
+++ b/packages/fastify-zod-reply/src/index.ts
@@ -1,71 +1,19 @@
-import fp from "fastify-plugin";
-import { createReply } from "./reply.js";
-import { mergeDeep } from "./utils.js";
+import pluginV4, { type FastifyReplyV4PluginOptions, type StatusCodeV4, type StatusCodeV4Builder } from './pluginV4.js';
+import { StatusCodeKey } from './types.js';
 
-export type StatusCode<TCode> = {
-  statusCode: TCode;
-  payload: any;
-}
-
-export interface FastifyStatusCode {
-  ok: StatusCode<200>;
-  created: StatusCode<201>;
-  accepted: StatusCode<202>;
-  noContent: StatusCode<204>;
-  badRequest: StatusCode<400>;
-  unauthorized: StatusCode<401>;
-  forbidden: StatusCode<403>;
-  notFound: StatusCode<404>;
-  notAcceptable: StatusCode<406>;
-  conflict: StatusCode<409>;
-  internalServerError: StatusCode<500>;
-}
-
-export type FastifyReplyPluginOptions = {
-  statusCodes?: {
-    [key in keyof FastifyStatusCode]?: FastifyStatusCode[key]
-  }
-}
 
 export type DecoratedReply = {
-  [key in keyof FastifyStatusCode]: <T>(val?: T) => T
+  [key in StatusCodeKey]: <T>(val?: T) => T
 }
 
 declare module 'fastify' {
   interface FastifyReply extends DecoratedReply {}
 }
 
-const defaultOptions: FastifyReplyPluginOptions = {
-  statusCodes: {
-    ok: { statusCode: 200, payload: { message: 'ok' } },
-    created: { statusCode: 201, payload: { message: 'created' } },
-    accepted: { statusCode: 202, payload: { message: 'accepted' } },
-    noContent: { statusCode: 204, payload: { message: 'noContent' } },
-    badRequest: { statusCode: 400, payload: { message: 'badRequest' } },
-    unauthorized: { statusCode: 401, payload: { message: 'unauthorized' } },
-    forbidden: { statusCode: 403, payload: { message: 'forbidden' } },
-    notFound: { statusCode: 404, payload: { message: 'notFound' } },
-    notAcceptable: { statusCode: 406, payload: { message: 'notAcceptable' } },
-    conflict: { statusCode: 409, payload: { message: 'conflict' } },
-    internalServerError: { statusCode: 500, payload: { message: 'internalServerError' } },
-  }
-}
-
-export default fp<FastifyReplyPluginOptions>(
-  async (fastify, opts) => {
-    const finalOptions = mergeDeep(defaultOptions, opts);
-    Object.entries(finalOptions.statusCodes!).forEach(([key, value]) => {
-      fastify.decorateReply(key, createReply(value.statusCode, value.payload))
-    })
-  },
-  {
-    fastify: "5.x",
-    name: '@efebia/fastify-zod-reply'
-  }
-);
-
 export * from './error.js';
+export * from './plugin.js';
 export * from './route.js';
 export * from './routeV4.js';
 export * from './types.js';
+export { FastifyReplyV4PluginOptions, pluginV4, StatusCodeV4, StatusCodeV4Builder };
 

--- a/packages/fastify-zod-reply/src/plugin.ts
+++ b/packages/fastify-zod-reply/src/plugin.ts
@@ -1,0 +1,78 @@
+import fp from "fastify-plugin";
+import { z } from "zod/v4";
+import { createReply } from "./reply.js";
+import { StatusCodeKey } from "./types.js";
+import { statusByText } from "./utils.js";
+
+export type StatusCode<TSchema extends z.ZodType> = {
+  statusCode: number;
+  payload: z.output<TSchema>;
+  schema: TSchema;
+};
+
+export class StatusCodeBuilder<TOpts extends Partial<Record<StatusCodeKey, StatusCode<any>>> = {}> {
+  constructor(readonly obj: TOpts = {} as any) {}
+  /**
+   *
+   * @param key Key to set (reference {@link statusByText})
+   * @param param1 Default schema and payload. These will be used when the response schema doesn't have the specified status code
+   * @returns A new builder with the correct properties
+   */
+  set<
+    TKey extends keyof TOpts extends never ? StatusCodeKey : Exclude<StatusCodeKey, keyof TOpts>,
+    TSchema extends z.ZodType
+  >(key: TKey, { schema, payload }: { schema: TSchema; payload: z.output<TSchema> }) {
+    return new StatusCodeBuilder<TOpts & { [key in TKey]: StatusCode<TSchema> }>({
+      ...this.obj,
+      [key]: { statusCode: statusByText[key], schema, payload },
+    } as any);
+  }
+}
+
+const messageSchema = z.object({ message: z.string() });
+
+
+export type FastifyReplyPluginOptions = {
+  statusCodes?: StatusCodeBuilder;
+};
+
+const defaultOptions: FastifyReplyPluginOptions = {
+  statusCodes: new StatusCodeBuilder()
+    .set("ok", { schema: messageSchema, payload: { message: "ok" } })
+    .set("created", { schema: messageSchema, payload: { message: "created" } })
+    .set("accepted", { schema: messageSchema, payload: { message: "accepted" } })
+    .set("noContent", { schema: z.undefined(), payload: undefined })
+    .set("badRequest", { schema: messageSchema, payload: { message: "badRequest" } })
+    .set("unauthorized", { schema: messageSchema, payload: { message: "unauthorized" } })
+    .set("forbidden", { schema: messageSchema, payload: { message: "forbidden" } })
+    .set("notFound", { schema: messageSchema, payload: { message: "notFound" } })
+    .set("notAcceptable", { schema: messageSchema, payload: { message: "notAcceptable" } })
+    .set("conflict", { schema: messageSchema, payload: { message: "conflict" } })
+    .set("internalServerError", { schema: messageSchema, payload: { message: "internalServerError" } })
+};
+
+/**
+ * Example on how to use it:
+ * fastify.register(plugin, {
+ *  statusCodes: new StatusCodeV4Builder().set('ok', 200, z.object({ message: z.string(), additionalProp1: z.string() }), { message: 'ok', additionalProp1: 'test' })
+ * })
+ * This will use the defaults, but sets `ok` with the new schema
+ */
+export default fp<FastifyReplyPluginOptions>(
+  async (fastify, opts) => {
+    const finalOptions: FastifyReplyPluginOptions = {
+      statusCodes: new StatusCodeBuilder({
+        ...defaultOptions.statusCodes?.obj,
+        ...opts.statusCodes?.obj,
+      }),
+    };
+    Object.entries(finalOptions.statusCodes?.obj || {}).forEach(([key, value]: [key: string, value: StatusCode<any>]) => {
+      fastify.decorateReply(key, createReply(value.statusCode, value.payload));
+    });
+  },
+  {
+    fastify: "5.x",
+    name: "@efebia/fastify-zod-reply",
+  }
+);
+

--- a/packages/fastify-zod-reply/src/plugin.ts
+++ b/packages/fastify-zod-reply/src/plugin.ts
@@ -1,5 +1,5 @@
 import fp from "fastify-plugin";
-import { z } from "zod/v4";
+import { z } from "zod";
 import { createReply } from "./reply.js";
 import { StatusCodeKey } from "./types.js";
 import { statusByText } from "./utils.js";
@@ -54,7 +54,7 @@ const defaultOptions: FastifyReplyPluginOptions = {
 /**
  * Example on how to use it:
  * fastify.register(plugin, {
- *  statusCodes: new StatusCodeV4Builder().set('ok', 200, z.object({ message: z.string(), additionalProp1: z.string() }), { message: 'ok', additionalProp1: 'test' })
+ *  statusCodes: new StatusCodeBuilder().set('ok', 200, z.object({ message: z.string(), additionalProp1: z.string() }), { message: 'ok', additionalProp1: 'test' })
  * })
  * This will use the defaults, but sets `ok` with the new schema
  */

--- a/packages/fastify-zod-reply/src/plugin.ts
+++ b/packages/fastify-zod-reply/src/plugin.ts
@@ -54,7 +54,7 @@ const defaultOptions: FastifyReplyPluginOptions = {
 /**
  * Example on how to use it:
  * fastify.register(plugin, {
- *  statusCodes: new StatusCodeBuilder().set('ok', 200, z.object({ message: z.string(), additionalProp1: z.string() }), { message: 'ok', additionalProp1: 'test' })
+ *  statusCodes: new StatusCodeBuilder().set('ok', z.object({ message: z.string(), additionalProp1: z.string() }), { message: 'ok', additionalProp1: 'test' })
  * })
  * This will use the defaults, but sets `ok` with the new schema
  */
@@ -68,6 +68,11 @@ export default fp<FastifyReplyPluginOptions>(
     };
     Object.entries(finalOptions.statusCodes?.obj || {}).forEach(([key, value]: [key: string, value: StatusCode<any>]) => {
       fastify.decorateReply(key, createReply(value.statusCode, value.payload));
+      fastify.decorateReply(`SCHEMA_${value.statusCode}`, {
+        getter() {
+            return value.schema
+        }
+      });
     });
   },
   {

--- a/packages/fastify-zod-reply/src/pluginV4.ts
+++ b/packages/fastify-zod-reply/src/pluginV4.ts
@@ -52,9 +52,10 @@ const defaultOptions: FastifyReplyV4PluginOptions = {
 };
 
 /**
+ * Register plugin to use only with `routeV4`
  * Example on how to use it:
  * fastify.register(plugin, {
- *  statusCodes: new StatusCodeV4Builder().set('ok', 200, z.object({ message: z.string(), additionalProp1: z.string() }), { message: 'ok', additionalProp1: 'test' })
+ *  statusCodes: new StatusCodeV4Builder().set('ok', z.object({ message: z.string(), additionalProp1: z.string() }), { message: 'ok', additionalProp1: 'test' })
  * })
  * This will use the defaults, but sets `ok` with the new schema
  */
@@ -68,6 +69,11 @@ export default fp<FastifyReplyV4PluginOptions>(
     };
     Object.entries(finalOptions.statusCodes?.obj || {}).forEach(([key, value]: [key: string, value: StatusCodeV4<any>]) => {
       fastify.decorateReply(key, createReply(value.statusCode, value.payload));
+      fastify.decorateReply(`SCHEMA_${value.statusCode}`, {
+        getter() {
+            return value.schema
+        }
+      });
     });
   },
   {

--- a/packages/fastify-zod-reply/src/pluginV4.ts
+++ b/packages/fastify-zod-reply/src/pluginV4.ts
@@ -1,0 +1,78 @@
+import fp from "fastify-plugin";
+import { z } from "zod/v4";
+import { createReply } from "./reply.js";
+import { StatusCodeKey } from "./types.js";
+import { statusByText } from "./utils.js";
+
+export type StatusCodeV4<TSchema extends z.ZodType> = {
+  statusCode: number;
+  payload: z.output<TSchema>;
+  schema: TSchema;
+};
+
+export class StatusCodeV4Builder<TOpts extends Partial<Record<StatusCodeKey, StatusCodeV4<any>>> = {}> {
+  constructor(readonly obj: TOpts = {} as any) {}
+  /**
+   *
+   * @param key Key to set (reference {@link statusByText})
+   * @param param1 Default schema and payload. These will be used when the response schema doesn't have the specified status code
+   * @returns A new builder with the correct properties
+   */
+  set<
+    TKey extends keyof TOpts extends never ? StatusCodeKey : Exclude<StatusCodeKey, keyof TOpts>,
+    TSchema extends z.ZodType
+  >(key: TKey, { schema, payload }: { schema: TSchema; payload: z.output<TSchema> }) {
+    return new StatusCodeV4Builder<TOpts & { [key in TKey]: StatusCodeV4<TSchema> }>({
+      ...this.obj,
+      [key]: { statusCode: statusByText[key], schema, payload },
+    } as any);
+  }
+}
+
+const messageSchema = z.object({ message: z.string() });
+
+
+export type FastifyReplyV4PluginOptions = {
+  statusCodes?: StatusCodeV4Builder;
+};
+
+const defaultOptions: FastifyReplyV4PluginOptions = {
+  statusCodes: new StatusCodeV4Builder()
+    .set("ok", { schema: messageSchema, payload: { message: "ok" } })
+    .set("created", { schema: messageSchema, payload: { message: "created" } })
+    .set("accepted", { schema: messageSchema, payload: { message: "accepted" } })
+    .set("noContent", { schema: z.undefined(), payload: undefined })
+    .set("badRequest", { schema: messageSchema, payload: { message: "badRequest" } })
+    .set("unauthorized", { schema: messageSchema, payload: { message: "unauthorized" } })
+    .set("forbidden", { schema: messageSchema, payload: { message: "forbidden" } })
+    .set("notFound", { schema: messageSchema, payload: { message: "notFound" } })
+    .set("notAcceptable", { schema: messageSchema, payload: { message: "notAcceptable" } })
+    .set("conflict", { schema: messageSchema, payload: { message: "conflict" } })
+    .set("internalServerError", { schema: messageSchema, payload: { message: "internalServerError" } })
+};
+
+/**
+ * Example on how to use it:
+ * fastify.register(plugin, {
+ *  statusCodes: new StatusCodeV4Builder().set('ok', 200, z.object({ message: z.string(), additionalProp1: z.string() }), { message: 'ok', additionalProp1: 'test' })
+ * })
+ * This will use the defaults, but sets `ok` with the new schema
+ */
+export default fp<FastifyReplyV4PluginOptions>(
+  async (fastify, opts) => {
+    const finalOptions: FastifyReplyV4PluginOptions = {
+      statusCodes: new StatusCodeV4Builder({
+        ...defaultOptions.statusCodes?.obj,
+        ...opts.statusCodes?.obj,
+      }),
+    };
+    Object.entries(finalOptions.statusCodes?.obj || {}).forEach(([key, value]: [key: string, value: StatusCodeV4<any>]) => {
+      fastify.decorateReply(key, createReply(value.statusCode, value.payload));
+    });
+  },
+  {
+    fastify: "5.x",
+    name: "@efebia/fastify-zod-reply",
+  }
+);
+

--- a/packages/fastify-zod-reply/src/route.test.ts
+++ b/packages/fastify-zod-reply/src/route.test.ts
@@ -2,13 +2,13 @@ import assert from "assert";
 import fastify from "fastify";
 import { describe, it } from "node:test";
 import z from "zod";
-import responsesPlugin from ".";
+import plugin, { StatusCodeBuilder } from "./plugin";
 import { createRoute, route } from "./route";
 
 describe("route", () => {
   it("should be able to return a 204 without any content", async () => {
     const app = fastify();
-    await app.register(responsesPlugin, { statusCodes: { noContent: { payload: undefined, statusCode: 204 } } });
+    await app.register(plugin, { statusCodes: new StatusCodeBuilder().set('noContent', { schema: z.undefined(), payload: undefined }) });
     app.get(
       "/",
       route({ Reply: z.object({ 204: z.undefined() }) }, async (req, reply) => {
@@ -25,7 +25,7 @@ describe("route", () => {
   });
   it("should fail if you send a 204 with content", async () => {
     const app = fastify();
-    await app.register(responsesPlugin, { statusCodes: { noContent: { payload: undefined, statusCode: 204 } } });
+    await app.register(plugin, { statusCodes: new StatusCodeBuilder().set('noContent', { schema: z.undefined(), payload: undefined }) });
 
     app.get(
       "/",
@@ -43,7 +43,7 @@ describe("route", () => {
   });
   it("should be able to return a 200 with content", async () => {
     const app = fastify();
-    await app.register(responsesPlugin, { statusCodes: { noContent: { payload: undefined, statusCode: 204 } } });
+    await app.register(plugin, { statusCodes: new StatusCodeBuilder().set('noContent', { schema: z.undefined(), payload: undefined }) });
     app.get(
       "/",
       route({ Reply: z.object({ 200: z.object({ id: z.string() }) }) }, async (req, reply) => {

--- a/packages/fastify-zod-reply/src/route.ts
+++ b/packages/fastify-zod-reply/src/route.ts
@@ -1,10 +1,15 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from 'zod';
 import { zodToJsonSchema, type JsonSchema7ObjectType } from 'zod-to-json-schema';
+import { FastifyZodReplyError } from './error.js';
 import { APIHandler, APIOptions, RouteSecurity, RouteTag } from './types.js';
 
-const mapZodError = (zodError: z.ZodError, prefix: string) =>
-    zodError.errors.map(issue => `Error at ${prefix}->${issue.path.join('->')}`).join(';\n');
+const mapZodError = (zodError: z.ZodError, prefix: string) => {
+    return zodError.issues.map(issue => {
+        const pathStr = `Error at ${prefix}->${issue.path.join('->')}`;
+        return issue.message ? `${pathStr}->${issue.message}` : pathStr;
+    }).join('\n');
+};
 
 export type BaseZodSchema = {
     Body?: z.ZodTypeAny;
@@ -122,16 +127,20 @@ export const createRoute = ({ strict: globalStrict = false }: RouteOptions = {})
             request.query = (results.find(r => r.tag === 'query') as any)?.data || {};
         },
         preSerialization: (request, reply, payload, done) => {
-            const foundSchema = findStatusCode(reply.statusCode, Object.entries(schema.Reply.shape))
+            const foundLocalSchema = findStatusCode(reply.statusCode, Object.entries(schema.Reply.shape))
+            const foundGlobalSchema = reply[`SCHEMA_${reply.statusCode}`]
+const foundSchema = foundLocalSchema?.[1] ?? foundGlobalSchema
             if (!foundSchema) {
-                request.log.warn(`[@efebia/fastify-zod-reply]: Reply schema of: ${request.routeOptions.url} does not have the specified status code: ${reply.statusCode}`)
-                return done(null, payload);
+                request.log.error(`[@efebia/fastify-zod-reply]: Reply schema of: ${request.routeOptions.url} does not have the specified status code: ${reply.statusCode} nor there is a global schema for this status code.`)
+                reply.code(500 as any)
+                return done(new FastifyZodReplyError(`Reply schema of: ${request.routeOptions.url} does not have the specified status code: ${reply.statusCode} nor there is a global schema for this status code.`, 500));
             }
-            const serialized = (foundSchema[1] as z.AnyZodObject).safeParse(payload);
+            const serialized = (foundSchema as z.ZodType).safeParse(payload);
             if (serialized.success) {
                 return done(null, serialized.data);
             }
-            return done(new Error(mapZodError(serialized.error, 'reply')));
+            reply.code(500 as any)
+            return done(new FastifyZodReplyError(mapZodError(serialized.error, 'reply'), 500));
         },
     };
 }

--- a/packages/fastify-zod-reply/src/routeV4.test.ts
+++ b/packages/fastify-zod-reply/src/routeV4.test.ts
@@ -59,6 +59,41 @@ describe("routeV4", () => {
     assert.deepStrictEqual(response.json(), { id: "test" });
     assert.equal(response.headers["content-type"], "application/json; charset=utf-8");
   });
+  it("should be able to use global schema if no schema is defined in response", async () => {
+    const app = fastify();
+    await app.register(pluginV4);
+    app.get(
+      "/",
+      //@ts-ignore
+      routeV4({ Reply: z.object({ 200: z.object({ id: z.string() }) }) }, async (req, reply) => {
+        return reply.forbidden({ message: "test" });
+      })
+    );
+    const response = await app.inject({
+      method: "GET",
+      url: "/",
+    });
+
+    assert.deepStrictEqual(response.json(), { message: "test" });
+    assert.equal(response.headers["content-type"], "application/json; charset=utf-8");
+  });
+  it("should throw if not matching global schema if no schema is defined in response", async () => {
+    const app = fastify();
+    await app.register(pluginV4);
+    app.get(
+      "/",
+      //@ts-ignore
+      routeV4({ Reply: z.object({ 200: z.object({ id: z.string() }) }) }, async (req, reply) => {
+        return reply.forbidden({ test: "test" });
+      })
+    );
+    const response = await app.inject({
+      method: "GET",
+      url: "/",
+    });
+    assert.deepStrictEqual(response.json(), { statusCode: 500, error: 'Internal Server Error', message: 'Error at reply->message->Invalid input: expected string, received undefined' });
+    assert.equal(response.headers["content-type"], "application/json; charset=utf-8");
+  });
   describe("strict", () => {
     const exampleSchema = z.object({ id: z.string() });
     it("strict true local mode should add additionalProperties: false", () => {

--- a/packages/fastify-zod-reply/src/routeV4.test.ts
+++ b/packages/fastify-zod-reply/src/routeV4.test.ts
@@ -2,13 +2,13 @@ import assert from "assert";
 import fastify from "fastify";
 import { describe, it } from "node:test";
 import z from "zod/v4";
-import responsesPlugin from "./index";
+import pluginV4, { StatusCodeV4Builder } from "./pluginV4";
 import { createRouteV4, routeV4 } from "./routeV4";
 
 describe("routeV4", () => {
   it("should be able to return a 204 without any content", async () => {
     const app = fastify();
-    await app.register(responsesPlugin, { statusCodes: { noContent: { payload: undefined, statusCode: 204 } } });
+    await app.register(pluginV4, { statusCodes: new StatusCodeV4Builder().set('noContent', { schema: z.undefined(), payload: undefined }) });
     app.get(
       "/",
       routeV4({ Reply: z.object({ 204: z.undefined() }) }, async (req, reply) => {
@@ -25,7 +25,7 @@ describe("routeV4", () => {
   });
   it("should fail if you send a 204 with content", async () => {
     const app = fastify();
-    await app.register(responsesPlugin, { statusCodes: { noContent: { payload: undefined, statusCode: 204 } } });
+    await app.register(pluginV4, { statusCodes: new StatusCodeV4Builder().set('noContent', { schema: z.undefined(), payload: undefined }) });
 
     app.get(
       "/",
@@ -43,7 +43,7 @@ describe("routeV4", () => {
   });
   it("should be able to return a 200 with content", async () => {
     const app = fastify();
-    await app.register(responsesPlugin, { statusCodes: { noContent: { payload: undefined, statusCode: 204 } } });
+    await app.register(pluginV4, { statusCodes: new StatusCodeV4Builder().set('noContent', { schema: z.undefined(), payload: undefined }) });
     app.get(
       "/",
       routeV4({ Reply: z.object({ 200: z.object({ id: z.string() }) }) }, async (req, reply) => {

--- a/packages/fastify-zod-reply/src/types.ts
+++ b/packages/fastify-zod-reply/src/types.ts
@@ -23,3 +23,5 @@ export type APIHandler<RouteInterface extends RouteGenericInterface = RouteGener
 
 export interface RouteTag {}
 export interface RouteSecurity {}
+
+export type StatusCodeKey = 'ok' | 'created' | 'accepted' | 'noContent' | 'badRequest' | 'unauthorized' | 'forbidden' | 'notFound' | 'notAcceptable' | 'conflict' | 'internalServerError'

--- a/packages/fastify-zod-reply/src/utils.ts
+++ b/packages/fastify-zod-reply/src/utils.ts
@@ -1,26 +1,42 @@
+import { StatusCodeKey } from "./types";
+
 export function isObject(item: any) {
-    return (item && typeof item === 'object' && !Array.isArray(item));
-  }
-  
-  /**
-   * Deep merge two objects.
-   * @param target
-   * @param ...sources
-   */
-  export function mergeDeep<TResult extends object>(target: TResult, ...sources: any[]): TResult {
-    if (!sources.length) return target;
-    const source = sources.shift();
-  
-    if (isObject(target) && isObject(source)) {
-      for (const key in source) {
-        if (isObject(source[key])) {
-          if (!target[key]) Object.assign(target, { [key]: {} });
-          mergeDeep(target[key], source[key]);
-        } else {
-          Object.assign(target, { [key]: source[key] });
-        }
+  return item && typeof item === "object" && !Array.isArray(item);
+}
+
+/**
+ * Deep merge two objects.
+ * @param target
+ * @param ...sources
+ */
+export function mergeDeep<TResult extends object>(target: TResult, ...sources: any[]): TResult {
+  if (!sources.length) return target;
+  const source = sources.shift();
+
+  if (isObject(target) && isObject(source)) {
+    for (const key in source) {
+      if (isObject(source[key])) {
+        if (!target[key]) Object.assign(target, { [key]: {} });
+        mergeDeep(target[key], source[key]);
+      } else {
+        Object.assign(target, { [key]: source[key] });
       }
     }
-  
-    return mergeDeep(target, ...sources);
   }
+
+  return mergeDeep(target, ...sources);
+}
+
+export const statusByText: Record<StatusCodeKey, number> = {
+  ok: 200,
+  created: 201,
+  accepted: 202,
+  noContent: 204,
+  badRequest: 400,
+  unauthorized: 401,
+  forbidden: 403,
+  notFound: 404,
+  notAcceptable: 406,
+  conflict: 409,
+  internalServerError: 500,
+};

--- a/packages/fastify-zod-reply/src/utils.ts
+++ b/packages/fastify-zod-reply/src/utils.ts
@@ -1,4 +1,4 @@
-import { StatusCodeKey } from "./types";
+import { StatusCodeKey } from "./types.js";
 
 export function isObject(item: any) {
   return item && typeof item === "object" && !Array.isArray(item);


### PR DESCRIPTION
Add support for setting up global schemas, by default all global schemas will have this format:
```json
{
    "message": "string"
}
```
Except for 204 which won't return anything

Also changed the way in which you're supposed to override status codes to allow typesafety.