### PR TITLE
[ @efebia/fastify-zod-reply ]: Improve error handling

### DIFF
--- a/packages/fastify-zod-reply/package.json
+++ b/packages/fastify-zod-reply/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@efebia/fastify-zod-reply",
-    "version": "1.1.0",
+    "version": "1.2.2",
     "license": "MIT",
     "dependencies": {
         "fastify": "^5.3.0",

--- a/packages/fastify-zod-reply/src/routeV4.test.ts
+++ b/packages/fastify-zod-reply/src/routeV4.test.ts
@@ -59,6 +59,44 @@ describe("routeV4", () => {
     assert.deepStrictEqual(response.json(), { id: "test" });
     assert.equal(response.headers["content-type"], "application/json; charset=utf-8");
   });
+  it("should throw an error if returning 200 but it is not in response schema", async () => {
+    const app = fastify();
+    await app.register(responsesPlugin, { statusCodes: { noContent: { payload: undefined, statusCode: 204 } } });
+    app.get(
+      "/",
+      routeV4({ Reply: z.object({ 200: z.object({ id: z.string() }) }) }, async (req, reply) => {
+        return reply.created({ id: "test" });
+      })
+    );
+    const response = await app.inject({
+      method: "GET",
+      url: "/",
+    });
+
+    assert.deepStrictEqual(response.json(), {
+      statusCode: 500,
+      error: "Internal Server Error",
+      message: "Reply schema of: / does not have the specified status code: 201.",
+    });
+    assert.equal(response.headers["content-type"], "application/json; charset=utf-8");
+  });
+  it("should not throw an error if returning 400 but it is not in response schema and return as-is", async () => {
+    const app = fastify();
+    await app.register(responsesPlugin, { statusCodes: { noContent: { payload: undefined, statusCode: 204 } } });
+    app.get(
+      "/",
+      routeV4({ Reply: z.object({ 200: z.object({ id: z.string() }) }) }, async (req, reply) => {
+        return reply.badRequest({ id: "test" });
+      })
+    );
+    const response = await app.inject({
+      method: "GET",
+      url: "/",
+    });
+
+    assert.deepStrictEqual(response.json(), { id: "test" });
+    assert.equal(response.headers["content-type"], "application/json; charset=utf-8");
+  });
   describe("strict", () => {
     const exampleSchema = z.object({ id: z.string() });
     it("strict true local mode should add additionalProperties: false", () => {

--- a/packages/fastify-zod-reply/src/routeV4.ts
+++ b/packages/fastify-zod-reply/src/routeV4.ts
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from 'zod/v4';
+import { FastifyZodReplyError } from './error.js';
 import { APIHandler, APIOptions, RouteSecurity, RouteTag } from './types.js';
 
 
-const mapZodError = (zodError, prefix) => {
+const mapZodError = (zodError: z.ZodError, prefix: string) => {
     return zodError.issues.map(issue => {
         const pathStr = `Error at ${prefix}->${issue.path.join('->')}`;
         return issue.message ? `${pathStr}->${issue.message}` : pathStr;
@@ -124,14 +125,15 @@ export const createRouteV4 = ({ strict: globalStrict = false }: RouteV4Options =
         preSerialization: (request, reply, payload, done) => {
             const foundSchema = findStatusCode(reply.statusCode, Object.entries(schema.Reply.shape))
             if (!foundSchema) {
-                request.log.warn(`[@efebia/fastify-zod-reply]: Reply schema of: ${request.routeOptions.url} does not have the specified status code: ${reply.statusCode}`)
-                return done(null, payload);
+                if (reply.statusCode >= 400) return done(null, payload)
+                request.log.warn(`[@efebia/fastify-zod-reply]: Reply schema of: ${request.routeOptions.url} does not have the specified status code: ${reply.statusCode}.`)
+                return done(new FastifyZodReplyError(`Reply schema of: ${request.routeOptions.url} does not have the specified status code: ${reply.statusCode}.`, 500));
             }
-            const serialized = (foundSchema[1] as z.ZodObject).safeParse(payload);
+            const serialized = (foundSchema[1] as z.ZodType).safeParse(payload);
             if (serialized.success) {
                 return done(null, serialized.data);
             }
-            return done(new Error(mapZodError(serialized.error, 'reply')));
+            return done(new FastifyZodReplyError(mapZodError(serialized.error, 'reply'), 500));
         },
     };
 }


### PR DESCRIPTION
- Throw error if status code is < 400 and reply has no schema
- Not throw error if status code is >= 400 and reply has no schema
- Put a 500 status code for errors when serializing response